### PR TITLE
Fix Cyan/Magenta box_lines and Name Backgrounds for Red and Green names

### DIFF
--- a/src/main/resources/www/main.js
+++ b/src/main/resources/www/main.js
@@ -1946,8 +1946,8 @@ function increase_brightness(dec, percent) {
         g = (dec >> 8) & 0xff,
         b = dec & 0xff;
 
-    let f = n => 0 | (1 << 8) + n + (256 - n) * percent / 100;
-    return (f(r) << 16) + (f(g) << 8) + f(b);
+    let f = n => Math.min(255, n + (255 - n) * percent / 100);
+    return Math.floor((f(r) << 16) + (f(g) << 8) + f(b));
 }
 
 function lerp(v0, v1, t) {

--- a/src/main/resources/www/main.js
+++ b/src/main/resources/www/main.js
@@ -1942,12 +1942,19 @@ function updatePlayerData() {
 
 // https://stackoverflow.com/questions/6443990/javascript-calculate-brighter-colour
 function increase_brightness(dec, percent) {
-    let r = (dec >> 16) & 0xff,
-        g = (dec >> 8) & 0xff,
-        b = dec & 0xff;
+    const r = (dec >> 16) & 0xff;
+    const g = (dec >> 8) & 0xff;
+    const b = dec & 0xff;
 
-    let f = n => Math.min(255, n + (255 - n) * percent / 100);
-    return Math.floor((f(r) << 16) + (f(g) << 8) + f(b));
+    const f = (ch) => {
+        return Math.min(255, ch + ((255 - ch) * percent / 100));
+    };
+
+    const newR = f(r);
+    const newG = f(g);
+    const newB = f(b);
+
+    return (f(r) << 16) + (f(g) << 8) + f(b);
 }
 
 function lerp(v0, v1, t) {

--- a/src/main/resources/www/main.js
+++ b/src/main/resources/www/main.js
@@ -1946,10 +1946,7 @@ function increase_brightness(dec, percent) {
     const g = (dec >> 8) & 0xff;
     const b = dec & 0xff;
 
-    const f = (ch) => {
-        return Math.min(255, ch + ((255 - ch) * percent / 100));
-    };
-
+    const f = ch => Math.min(255, ch + ((255 - ch) * percent / 100));
     return (f(r) << 16) + (f(g) << 8) + f(b);
 }
 

--- a/src/main/resources/www/main.js
+++ b/src/main/resources/www/main.js
@@ -1950,10 +1950,6 @@ function increase_brightness(dec, percent) {
         return Math.min(255, ch + ((255 - ch) * percent / 100));
     };
 
-    const newR = f(r);
-    const newG = f(g);
-    const newB = f(b);
-
     return (f(r) << 16) + (f(g) << 8) + f(b);
 }
 


### PR DESCRIPTION
Basically the increase brightness function creates invalid colors such as Hex 200D9CE. This leads to truncating to incorrect colors in many cases. Replacing the function in local testing has fixed all issues.